### PR TITLE
Add Python 3 compatibility string

### DIFF
--- a/octoprint_pause_for_user_event/__init__.py
+++ b/octoprint_pause_for_user_event/__init__.py
@@ -53,6 +53,7 @@ class pause_for_user_event(octoprint.plugin.SettingsPlugin):
 # ("OctoPrint-PluginSkeleton"), you may define that here. Same goes for the other metadata derived from setup.py that
 # can be overwritten via __plugin_xyz__ control properties. See the documentation for that.
 __plugin_name__ = "PauseForUser Event Plugin"
+__plugin_pythoncompat__ = ">=2.7,<4"  # Python 2 and 3
 
 def __plugin_load__():
     global __plugin_implementation__


### PR DESCRIPTION
Since Python 2 is EOL and all new users very shortly will be Py3, they would not be able to install and run this plugin.

There's the documentation here, if you want to setup dual environments for testing:
https://docs.octoprint.org/en/master/plugins/python3_migration.html

Or, to update your existing environment, one time script:
https://octoprint.org/blog/2020/09/10/upgrade-to-py3/

Closes #3 

If you want to test this, or until this PR gets merged, and you (as a user) want to install the plugin - use this URL in the plugin manager > Get More> ...from URL:
```
https://github.com/cp2004/OctoPrint-PauseForUserEvent/archive/patch-1.zip
```